### PR TITLE
Add button for "stage" asset selector

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -11,6 +11,17 @@
       "isPalette": true,
       "includePaths": [ "**.docx**" ],
       "paletteRect": "top: auto; bottom: 20px; left: 20px; width:1000px; height:700px"
+    },
+    {
+      "id": "asset-library-stage",
+      "title": "AEM Assets Library Stage",
+      "environments": [
+        "edit"
+      ],
+      "url": "https://rail--aem-assets-boilerplate--hlxsites.hlx.page/aem-asset-selector-stage",
+      "isPalette": true,
+      "includePaths": [ "**.docx**" ],
+      "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
     }
   ]
 }


### PR DESCRIPTION
This PR adds another button to the sidekick for a "stage" asset selector. This is a temporary solution so that we can more safely iterate on the selector.

This button will point to the selector on the `rail` branch so that we can commit to that branch and see selector changes without needing to commit to `main`.

The button also uses an application-level client ID, and points to an AEM environment in cloud manager stage.

Test URLs:
- Before: https://main--aem-assets-boilerplate--hlxsites.hlx.page/
- After: https://selector-stage--aem-assets-boilerplate--hlxsites.hlx.page/
